### PR TITLE
Fixed a bug related to inversion using topography

### DIFF
--- a/Interface.pyw
+++ b/Interface.pyw
@@ -1307,6 +1307,7 @@ class Window(QMainWindow):
     def _initPygimli(self, fname):
         ## Preparing inversion of data (pygimli)
         self.dataUI.invData.data = pg.DataContainer(fname, sensorTokens='s g')
+        self.dataUI.invData.data.sortSensorsX(incX=True)
         self.dataUI.invData.manager = TTMgr(self.dataUI.invData.data)
         self.dataUI.invData.mesh = self.dataUI.invData.manager.createMesh(data=self.dataUI.invData.data, paraMaxCellSize=self.dataUI.invData.meshMaxCellSize, paraDepth=self.dataUI.invData.meshDepthMax)
         self.invModelGraph.axes.clear()


### PR DESCRIPTION
While working on a SRT survey that has significant topography, I found a bug that made it impossible to run the inversion.
The output was:
```
(sardine) PS C:\Users\Marc\git\SardineReborn-0.4.4> python .\Interface.pyw
14/06/24 - 10:38:25 - pyGIMLi - INFO - Found 2 regions.
14/06/24 - 10:38:25 - pyGIMLi - INFO - Region with smallest marker set to background (marker=0)
14/06/24 - 10:38:25 - pyGIMLi - INFO - Creating forward mesh from region infos.
14/06/24 - 10:38:26 - pyGIMLi - INFO - Creating refined mesh (secnodes: 2) to solve forward task.
14/06/24 - 10:38:30 - pyGIMLi - ERROR - <class 'pygimli.frameworks.inversion.Inversion'>.convertStartModel(C:\Users\Marc\.conda\envs\sardine\lib\site-packages\pygimli\frameworks\inversion.py:205)
Starting model size invalid 74161 != 15056.
14/06/24 - 10:38:30 - pyGIMLi - INFO - Create gradient starting model. 500: 5000
14/06/24 - 10:38:30 - pyGIMLi - INFO - Created startmodel from forward operator: [0.00180324 0.0010421  0.00160058 ... 0.00020179 0.00021003 0.00020237]
*** C:/msys64/home/halbm/gimli/gimli/core/src/ttdijkstramodelling.cpp:500
Error!: There are cells with marker -1. Did you define a boundary region? (This is not needed).
Traceback (most recent call last):
  File ".\Interface.pyw", line 1865, in _runInversion
    self.dataUI.invData.manager.invert(data = self.dataUI.invData.data,
  File "C:\Users\Marc\.conda\envs\sardine\lib\site-packages\pygimli\physics\traveltime\TravelTimeManager.py", line 247, in invert
    slowness = super().invert(data, mesh, **kwargs)
  File "C:\Users\Marc\.conda\envs\sardine\lib\site-packages\pygimli\frameworks\methodManager.py", line 793, in invert
    self.fw.run(dataVals, errorVals, **kwargs)
  File "C:\Users\Marc\.conda\envs\sardine\lib\site-packages\pygimli\frameworks\inversion.py", line 587, in run
    self.inv.start()
  File "C:\Users\Marc\.conda\envs\sardine\lib\site-packages\pygimli\physics\traveltime\modelling.py", line 84, in createJacobian
    return self._core.createJacobian(par)
RuntimeError: C:/msys64/home/halbm/gimli/gimli/core/src/sparsematrix.h:342              GIMLI::SparseMapMatrix<ValueType, IndexType>::MatElement GIMLI::SparseMapMatrix<ValueType, IndexType>::Aux::operator[](IndexType) [with ValueType = double; IndexType = long long unsigned int; GIMLI::SparseMapMatrix<ValueType, IndexType>::MatElement = GIMLI::MatrixElement<double, long long unsigned int, std::map<std::pair<long long unsigned int, long long unsigned int>, double, std::less<std::pair<long long unsigned int, long long unsigned int> >, std::allocator<std::pair<const std::pair<long long unsigned int, long long unsigned int>, double> > > >]  idx = 18446744073709551615, 0 maxcol = 15056 stype: 0
(sardine) PS C:\Users\Marc\git\SardineReborn-0.4.4>
```
When inspecting the mesh I found that the surface topography was intersecting itself: ![self-intersecting_surface](https://github.com/hadrienmichel/SardineReborn/assets/21953917/6720f809-f77e-4a59-920d-399b35999e1f)
I figured that the location of the sensors have to be sorted to make sure the mesh will be created correctly.

This fixes this bug.